### PR TITLE
WIP - Add workaround provided in issue #5 comments

### DIFF
--- a/src/main/resources/com/rimerosolutions/maven/plugins/wrapper/mvnw_footer.bat
+++ b/src/main/resources/com/rimerosolutions/maven/plugins/wrapper/mvnw_footer.bat
@@ -4,7 +4,7 @@ goto runm2
 @REM Start MAVEN2
 :runm2
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
-%MAVEN_JAVA_EXE% %MAVEN_OPTS% -classpath %WRAPPER_JAR% %WRAPPER_LAUNCHER% %MAVEN_CMD_LINE_ARGS%
+%MAVEN_JAVA_EXE% %MAVEN_OPTS% -Dmaven.multiModuleProjectDirectory=%CD% -classpath %WRAPPER_JAR% %WRAPPER_LAUNCHER% %MAVEN_CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error
 goto end
 

--- a/src/main/resources/com/rimerosolutions/maven/plugins/wrapper/mvnw_header
+++ b/src/main/resources/com/rimerosolutions/maven/plugins/wrapper/mvnw_header
@@ -134,5 +134,6 @@ fi
 DIR=`dirname "$0"`
 
 exec "$JAVACMD" \
-  $MAVEN_OPTS \
+     $MAVEN_OPTS \
+     -Dmaven.multiModuleProjectDirectory="$PWD" \
   -classpath \


### PR DESCRIPTION
Setting the maven.multiModuleProjectDirectory JVM variable to
resolve the current directory.

Also see additional comments in issue #5, as this might be only
mid-term workaround.