### PR TITLE
Add support for multiple distribution URIs (issue #10)

### DIFF
--- a/src/main/java/org/apache/maven/wrapper/PathAssembler.java
+++ b/src/main/java/org/apache/maven/wrapper/PathAssembler.java
@@ -43,11 +43,11 @@ public class PathAssembler
     /**
      * Determines the local locations for the distribution to use given the supplied configuration.
      */
-    public LocalDistribution getDistribution( WrapperConfiguration configuration )
+    public LocalDistribution getDistribution( WrapperConfiguration configuration, URI distributionUrl )
     {
-        String baseName = getDistName( configuration.getDistribution() );
+        String baseName = getDistName( distributionUrl );
         String distName = removeExtension( baseName );
-        String rootDirName = rootDirName( distName, configuration );
+        String rootDirName = rootDirName( distName, distributionUrl );
         File distDir =
             new File( getBaseDir( configuration.getDistributionBase() ), configuration.getDistributionPath() + "/"
                 + rootDirName );
@@ -57,9 +57,9 @@ public class PathAssembler
         return new LocalDistribution( distDir, distZip );
     }
 
-    private String rootDirName( String distName, WrapperConfiguration configuration )
+    private String rootDirName( String distName, URI distributionUrl )
     {
-        String urlHash = getMd5Hash( configuration.getDistribution().toString() );
+        String urlHash = getMd5Hash( distributionUrl.toString() );
         return String.format( "%s/%s", distName, urlHash );
     }
 

--- a/src/main/java/org/apache/maven/wrapper/WrapperConfiguration.java
+++ b/src/main/java/org/apache/maven/wrapper/WrapperConfiguration.java
@@ -16,6 +16,7 @@
 package org.apache.maven.wrapper;
 
 import java.net.URI;
+import java.util.List;
 
 public class WrapperConfiguration
 {
@@ -27,7 +28,7 @@ public class WrapperConfiguration
 
     private boolean alwaysDownload = Boolean.parseBoolean( System.getenv( ALWAYS_DOWNLOAD_ENV ) );
 
-    private URI distribution;
+    private List<URI> distribution;
 
     private String distributionBase = PathAssembler.MAVEN_USER_HOME_STRING;
 
@@ -39,7 +40,7 @@ public class WrapperConfiguration
 
     private boolean verifyDownload = false;
 
-    private URI checksum = null;
+    private List<URI> checksum = null;
 
     private Checksum checksumAlgorithm = null;
 
@@ -63,12 +64,12 @@ public class WrapperConfiguration
         this.alwaysUnpack = alwaysUnpack;
     }
 
-    public URI getDistribution()
+    public List<URI> getDistribution()
     {
         return distribution;
     }
 
-    public void setDistribution( URI distribution )
+    public void setDistribution( List<URI> distribution )
     {
         this.distribution = distribution;
     }
@@ -121,11 +122,11 @@ public class WrapperConfiguration
         this.verifyDownload = verifyDownload;
     }
 
-    public URI getChecksum() {
+    public List<URI> getChecksum() {
         return checksum;
     }
 
-    public void setChecksum( URI checksum ) {
+    public void setChecksum( List<URI> checksum ) {
         this.checksum = checksum;
     }
 

--- a/src/test/java/org/apache/maven/wrapper/MavenWrapperMojoTest.java
+++ b/src/test/java/org/apache/maven/wrapper/MavenWrapperMojoTest.java
@@ -16,15 +16,19 @@
 package org.apache.maven.wrapper;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
+
 
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.artifact.Artifact;
@@ -43,6 +47,9 @@ public class MavenWrapperMojoTest extends AbstractMojoTestCase {
         private static final String TEST_WRAPPER_DIR_LOCATION = "target/test-wrapper";
         private static final String TEST_SUPPORT_DIR_LOCATION = "support";
         private static final String TEST_DISTRIBUTION_URL = "http://mirrors.ibiblio.org/maven2/org/apache/maven/apache-maven";
+        private static final List<String> TEST_DISTRIBUTION_URL_LIST = Collections.unmodifiableList(Arrays.asList(
+                "http://mirrors.ibiblio.org/maven2/org/apache/maven/apache-maven",
+                "https://repo1.maven.org/maven2/org/apache/maven/apache-maven"));
         private static final String PLUGIN_TEST_FILE_LOCATION = "src/test/resources/org/apache/maven/wrapper/plugin-config.xml";
         private static final String PLUGIN_TEST_ARTIFACT_LOCATION = "src/test/resources/org/apache/maven/wrapper/dummy-wrapper-artifact.txt";
         private static final String MAVEN_RUNTIME_VERSION = "0.0.1";
@@ -95,17 +102,25 @@ public class MavenWrapperMojoTest extends AbstractMojoTestCase {
         }
 
         private String getExpectedDistributionUrl() {
-                StringBuilder sb = new StringBuilder(TEST_DISTRIBUTION_URL).append('/');
-                sb.append(MavenWrapperMojo.DIST_FILENAME_PATH_TEMPLATE);
-
-                return String.format(sb.toString(), MAVEN_RUNTIME_VERSION, MAVEN_RUNTIME_VERSION);
+                StringBuilder sb = new StringBuilder();
+                for (String testDistributionUrl : TEST_DISTRIBUTION_URL_LIST) {
+                        sb.append(testDistributionUrl).append('/');
+                        sb.append(String.format(MavenWrapperMojo.DIST_FILENAME_PATH_TEMPLATE, MAVEN_RUNTIME_VERSION, MAVEN_RUNTIME_VERSION));
+                        sb.append(",");
+                }
+                sb.setLength(sb.length() - 1);
+                return sb.toString();
         }
 
         private String getExpectedChecksumUrl() {
-                StringBuilder sb = new StringBuilder(TEST_DISTRIBUTION_URL).append('/');
-                sb.append(MavenWrapperMojo.CHECKSUM_FILENAME_PATH_TEMPLATE);
-
-                return String.format(sb.toString(), MAVEN_RUNTIME_VERSION, MAVEN_RUNTIME_VERSION, CHECKSUM_EXTENSION);
+                StringBuilder sb = new StringBuilder();
+                for (String testDistributionUrl : TEST_DISTRIBUTION_URL_LIST) {
+                        sb.append(testDistributionUrl).append('/');
+                        sb.append(String.format(MavenWrapperMojo.CHECKSUM_FILENAME_PATH_TEMPLATE, MAVEN_RUNTIME_VERSION, MAVEN_RUNTIME_VERSION, CHECKSUM_EXTENSION));
+                        sb.append(",");
+                }
+                sb.setLength(sb.length() - 1);
+                return sb.toString();
         }
 
         protected void setUp() throws Exception {
@@ -124,6 +139,7 @@ public class MavenWrapperMojoTest extends AbstractMojoTestCase {
 
                 assertNotNull(mojo.getWrapperDirectory());
                 assertNotNull(mojo.getBaseDistributionUrl());
+                assertNotNull(mojo.getBaseDistributionUrlList());
                 assertNotNull(mojo.getWrapperScriptDirectory());
                 assertNotNull(mojo.getMavenVersion());
                 assertNotNull(mojo.getVerifyDownload());
@@ -134,6 +150,7 @@ public class MavenWrapperMojoTest extends AbstractMojoTestCase {
                 assertEquals(wrapperSupportDir.getAbsolutePath(), mojo.getWrapperDirectory());
                 assertEquals(MAVEN_RUNTIME_VERSION, mojo.getMavenVersion());
                 assertEquals(TEST_DISTRIBUTION_URL, mojo.getBaseDistributionUrl());
+                assertEquals(TEST_DISTRIBUTION_URL_LIST, mojo.getBaseDistributionUrlList());
                 assertEquals(VERIFY_DOWNLOAD, mojo.getVerifyDownload());
                 assertEquals(CHECKSUM_EXTENSION, mojo.getChecksumExtension());
                 assertEquals(CHECKSUM_ALGORITHM, mojo.getChecksumAlgorithm());

--- a/src/test/java/org/apache/maven/wrapper/PathAssemblerTest.java
+++ b/src/test/java/org/apache/maven/wrapper/PathAssemblerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Collections;
 import java.util.regex.Pattern;
 
 import org.hamcrest.BaseMatcher;
@@ -34,7 +35,10 @@ import org.junit.Test;
  * @author Hans Dockter
  */
 public class PathAssemblerTest {
-        public static final String TEST_MAVEN_USER_HOME = "someUserHome";
+        private static final String TEST_MAVEN_USER_HOME = "someUserHome";
+        private static final URI TEST_DISTRIBUTION_URI = URI.create("http://server/dist/maven-0.9-bin.zip");
+        private static final URI TEST_DISTRIBUTION_NO_TYPE_URI = URI.create("http://server/dist/maven-1.0.zip");
+
         private PathAssembler pathAssembler = new PathAssembler(new File(TEST_MAVEN_USER_HOME));
         final WrapperConfiguration configuration = new WrapperConfiguration();
 
@@ -48,9 +52,9 @@ public class PathAssemblerTest {
 
         @Test
         public void distributionDirWithMavenUserHomeBase() throws Exception {
-                configuration.setDistribution(new URI("http://server/dist/maven-0.9-bin.zip"));
+                configuration.setDistribution(Collections.singletonList(TEST_DISTRIBUTION_URI));
 
-                File distributionDir = pathAssembler.getDistribution(configuration).getDistributionDir();
+                File distributionDir = pathAssembler.getDistribution(configuration, TEST_DISTRIBUTION_URI).getDistributionDir();
                 assertThat(distributionDir.getName(), matchesRegexp("[a-z0-9]+"));
                 assertThat(distributionDir.getParentFile(), equalTo(file(TEST_MAVEN_USER_HOME + "/somePath/maven-0.9-bin")));
         }
@@ -58,20 +62,20 @@ public class PathAssemblerTest {
         @Test
         public void distributionDirWithProjectBase() throws Exception {
                 configuration.setDistributionBase(PathAssembler.PROJECT_STRING);
-                configuration.setDistribution(new URI("http://server/dist/maven-0.9-bin.zip"));
+                configuration.setDistribution(Collections.singletonList(TEST_DISTRIBUTION_URI));
 
-                File distributionDir = pathAssembler.getDistribution(configuration).getDistributionDir();
+                File distributionDir = pathAssembler.getDistribution(configuration, TEST_DISTRIBUTION_URI).getDistributionDir();
                 assertThat(distributionDir.getName(), matchesRegexp("[a-z0-9]+"));
                 assertThat(distributionDir.getParentFile(), equalTo(file(currentDirPath() + "/somePath/maven-0.9-bin")));
         }
 
         @Test
         public void distributionDirWithUnknownBase() throws Exception {
-                configuration.setDistribution(new URI("http://server/dist/maven-1.0.zip"));
+                configuration.setDistribution(Collections.singletonList(TEST_DISTRIBUTION_NO_TYPE_URI));
                 configuration.setDistributionBase("unknownBase");
 
                 try {
-                        pathAssembler.getDistribution(configuration);
+                        pathAssembler.getDistribution(configuration, TEST_DISTRIBUTION_NO_TYPE_URI);
                         fail();
                 }
                 catch (RuntimeException e) {
@@ -81,9 +85,9 @@ public class PathAssemblerTest {
 
         @Test
         public void distZipWithMavenUserHomeBase() throws Exception {
-                configuration.setDistribution(new URI("http://server/dist/maven-1.0.zip"));
+                configuration.setDistribution(Collections.singletonList(TEST_DISTRIBUTION_NO_TYPE_URI));
 
-                File dist = pathAssembler.getDistribution(configuration).getZipFile();
+                File dist = pathAssembler.getDistribution(configuration, TEST_DISTRIBUTION_NO_TYPE_URI).getZipFile();
                 assertThat(dist.getName(), equalTo("maven-1.0.zip"));
                 assertThat(dist.getParentFile().getName(), matchesRegexp("[a-z0-9]+"));
                 assertThat(dist.getParentFile().getParentFile(),
@@ -93,9 +97,9 @@ public class PathAssemblerTest {
         @Test
         public void distZipWithProjectBase() throws Exception {
                 configuration.setZipBase(PathAssembler.PROJECT_STRING);
-                configuration.setDistribution(new URI("http://server/dist/maven-1.0.zip"));
+                configuration.setDistribution(Collections.singletonList(TEST_DISTRIBUTION_NO_TYPE_URI));
 
-                File dist = pathAssembler.getDistribution(configuration).getZipFile();
+                File dist = pathAssembler.getDistribution(configuration, TEST_DISTRIBUTION_NO_TYPE_URI).getZipFile();
                 assertThat(dist.getName(), equalTo("maven-1.0.zip"));
                 assertThat(dist.getParentFile().getName(), matchesRegexp("[a-z0-9]+"));
                 assertThat(dist.getParentFile().getParentFile(), equalTo(file(currentDirPath() + "/somePath/maven-1.0")));

--- a/src/test/java/org/apache/maven/wrapper/WrapperExecutorTest.java
+++ b/src/test/java/org/apache/maven/wrapper/WrapperExecutorTest.java
@@ -47,30 +47,36 @@ public class WrapperExecutorTest {
         public void loadWrapperMetadataFromFile() throws Exception {
                 WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile(propertiesFile, System.out);
 
-                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getDistribution());
-                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getConfiguration().getDistribution());
+                Assert.assertEquals(1, wrapper.getDistribution().size());
+                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getDistribution().get(0));
+                Assert.assertEquals(1, wrapper.getConfiguration().getDistribution().size());
+                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getConfiguration().getDistribution().get(0));
                 Assert.assertEquals("testDistBase", wrapper.getConfiguration().getDistributionBase());
                 Assert.assertEquals("testDistPath", wrapper.getConfiguration().getDistributionPath());
                 Assert.assertEquals("testZipBase", wrapper.getConfiguration().getZipBase());
                 Assert.assertEquals("testZipPath", wrapper.getConfiguration().getZipPath());
                 Assert.assertTrue(wrapper.getConfiguration().isVerifyDownload());
                 Assert.assertEquals(Checksum.MD5, wrapper.getConfiguration().getChecksumAlgorithm());
-                Assert.assertEquals(URI.create("http://server/test/maven.zip.md5"), wrapper.getConfiguration().getChecksum());
+                Assert.assertEquals(1, wrapper.getConfiguration().getChecksum().size());
+                Assert.assertEquals(URI.create("http://server/test/maven.zip.md5"), wrapper.getConfiguration().getChecksum().get(0));
         }
 
         @Test
         public void loadWrapperMetadataFromDirectory() throws Exception {
                 WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory(testDir, System.out);
 
-                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getDistribution());
-                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getConfiguration().getDistribution());
+                Assert.assertEquals(1, wrapper.getDistribution().size());
+                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getDistribution().get(0));
+                Assert.assertEquals(1, wrapper.getConfiguration().getDistribution().size());
+                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getConfiguration().getDistribution().get(0));
                 Assert.assertEquals("testDistBase", wrapper.getConfiguration().getDistributionBase());
                 Assert.assertEquals("testDistPath", wrapper.getConfiguration().getDistributionPath());
                 Assert.assertEquals("testZipBase", wrapper.getConfiguration().getZipBase());
                 Assert.assertEquals("testZipPath", wrapper.getConfiguration().getZipPath());
                 Assert.assertTrue(wrapper.getConfiguration().isVerifyDownload());
                 Assert.assertEquals(Checksum.MD5, wrapper.getConfiguration().getChecksumAlgorithm());
-                Assert.assertEquals(URI.create("http://server/test/maven.zip.md5"), wrapper.getConfiguration().getChecksum());
+                Assert.assertEquals(1, wrapper.getConfiguration().getChecksum().size());
+                Assert.assertEquals(URI.create("http://server/test/maven.zip.md5"), wrapper.getConfiguration().getChecksum().get(0));
         }
 
         @Test
@@ -97,8 +103,10 @@ public class WrapperExecutorTest {
 
                 WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile(propertiesFile, System.out);
 
-                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getDistribution());
-                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getConfiguration().getDistribution());
+                Assert.assertEquals(1, wrapper.getDistribution().size());
+                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getDistribution().get(0));
+                Assert.assertEquals(1, wrapper.getConfiguration().getDistribution().size());
+                Assert.assertEquals(new URI("http://server/test/maven.zip"), wrapper.getConfiguration().getDistribution().get(0));
                 Assert.assertEquals(PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getDistributionBase());
                 Assert.assertEquals(Installer.DEFAULT_DISTRIBUTION_PATH, wrapper.getConfiguration().getDistributionPath());
                 Assert.assertEquals(PathAssembler.MAVEN_USER_HOME_STRING, wrapper.getConfiguration().getZipBase());
@@ -210,8 +218,9 @@ public class WrapperExecutorTest {
                 writePropertiesFile(properties, propertiesFile, "header");
 
                 WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile(propertiesFile, System.out);
-                Assert.assertNotEquals("some/relative/url/to/bin.zip", wrapper.getDistribution().getSchemeSpecificPart());
-                Assert.assertTrue(wrapper.getDistribution().getSchemeSpecificPart().endsWith("some/relative/url/to/bin.zip"));
+                Assert.assertEquals(1, wrapper.getDistribution().size());
+                Assert.assertNotEquals("some/relative/url/to/bin.zip", wrapper.getDistribution().get(0).getSchemeSpecificPart());
+                Assert.assertTrue(wrapper.getDistribution().get(0).getSchemeSpecificPart().endsWith("some/relative/url/to/bin.zip"));
         }
 
         @Test
@@ -224,8 +233,9 @@ public class WrapperExecutorTest {
                 writePropertiesFile(properties, propertiesFile, "header");
 
                 WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile(propertiesFile, System.out);
-                Assert.assertNotEquals("some/relative/url/to/bin.md5", wrapper.getConfiguration().getChecksum().getSchemeSpecificPart());
-                Assert.assertTrue(wrapper.getConfiguration().getChecksum().getSchemeSpecificPart().endsWith("some/relative/url/to/bin.md5"));
+                Assert.assertEquals(1, wrapper.getConfiguration().getChecksum().size());
+                Assert.assertNotEquals("some/relative/url/to/bin.md5", wrapper.getConfiguration().getChecksum().get(0).getSchemeSpecificPart());
+                Assert.assertTrue(wrapper.getConfiguration().getChecksum().get(0).getSchemeSpecificPart().endsWith("some/relative/url/to/bin.md5"));
         }
 
         private void writePropertiesFile(Properties properties, File propertiesFile, String message) throws Exception {

--- a/src/test/resources/org/apache/maven/wrapper/plugin-config.xml
+++ b/src/test/resources/org/apache/maven/wrapper/plugin-config.xml
@@ -14,6 +14,11 @@
                                 <configuration>
                                         <!-- optional base distribution url -->
                                         <baseDistributionUrl>http://mirrors.ibiblio.org/maven2/org/apache/maven/apache-maven</baseDistributionUrl>
+                                        <!-- optional base distribution url -->
+                                        <baseDistributionUrlList>
+                                                <baseDistributionUrl>http://mirrors.ibiblio.org/maven2/org/apache/maven/apache-maven</baseDistributionUrl>
+                                                <baseDistributionUrl>https://repo1.maven.org/maven2/org/apache/maven/apache-maven</baseDistributionUrl>
+                                        </baseDistributionUrlList>
                                         <!-- optional folder for generated scripts -->
                                         <wrapperScriptDirectory>${basedir}/target/test-wrapper</wrapperScriptDirectory>
                                         <!-- optional wrapper jar output folder -->


### PR DESCRIPTION
Although this change accomplishes the task of supporting multiple distribution URIs which addresses many (most?) of the use cases where one source becomes unavailable it does fall short of a complete refactor. However, this is a more surgical solution and is backwards compatible with both the pom and generated wrapper properties. 

The ideal solution would be to refactor the distributions entirely into an object list and specify all the relevant properties per distribution. For example, the verification settings would be specified per distribution alongside the URI. This approach would likely break backwards compatibility (or at least have to go to much greater lengths to preserve it).

In the end this simpler approach of only having a list of distribution URIs with the remaining properties applying to all distributions covers the use case where the distribution URIs are mirrors as is typically the case with Maven repositories.
